### PR TITLE
Add wildcard and partial name search

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ dotnet add package WikiDataLib
 
 ### `WikiData.WikiPeopleSearchAsync`
 
-Search for people in WikiData by name. Returns a collection of matching people.
+Search for people in WikiData by name. Returns a collection of matching people. The search is case-insensitive, supports partial matches, and accepts `*` and `?` wildcard patterns.
 
 ```csharp
 public static async Task<Collection<WikiPerson>> WikiPeopleSearchAsync(
@@ -29,8 +29,12 @@ public static async Task<Collection<WikiPerson>> WikiPeopleSearchAsync(
 var people = await WikiData.WikiPeopleSearchAsync("Ada");
 ```
 
+```csharp
+var people = await WikiData.WikiPeopleSearchAsync("*Presley*");
+```
+
 **Parameters:**
-- `searchString` — name to search for (throws `ArgumentException` if null or whitespace)
+- `searchString` — name or wildcard pattern to search for (throws `ArgumentException` if null or whitespace)
 - `cancellationToken` — optional cancellation token
 
 ### `WikiData.GetWikiPersonAsync`

--- a/WikiDataLib/README.md
+++ b/WikiDataLib/README.md
@@ -286,8 +286,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Changelog
 
-### v1.1.6 (Current)
-- Documentation-only release: updated NuGet README to reflect current version and fix dependency notes
+### v1.1.7 (Current)
+- Added partial and wildcard people search examples and documentation
 
 ### v1.1.5
 - Fixed `System.Text.Json` version compatibility (`netstandard2.0` uses v8.0.5; `net10.0` uses built-in)

--- a/WikiDataLib/WikiData.cs
+++ b/WikiDataLib/WikiData.cs
@@ -70,7 +70,7 @@ namespace WikiDataLib
                     return new Collection<WikiPerson>();
                 }
 
-                var query = BuildSearchQuery(entityIds);
+                var query = BuildSearchQuery(entityIds, searchPattern);
                 var root = await ExecuteSparqlQueryAsync(query, cancellationToken).ConfigureAwait(false);
 
                 if (!TryGetBindings(root, out var bindings))
@@ -179,13 +179,16 @@ namespace WikiDataLib
             }
         }
 
-        private static string BuildSearchQuery(Collection<int> entityIds)
+        private static string BuildSearchQuery(Collection<int> entityIds, string searchPattern)
         {
             var itemValues = string.Join(" ", entityIds.Select(id => $"wd:Q{id}"));
+            var escapedSearchPattern = EscapeSparqlStringLiteral(searchPattern);
 
             return "SELECT distinct (SAMPLE(?image)as ?image) ?item ?itemLabel ?itemDescription" +
                 " (SAMPLE(?DR) as ?DR)(SAMPLE(?RIP) as ?RIP)(SAMPLE(?article) as ?article) " +
-                "WHERE {VALUES ?item { " + itemValues + " } ?item wdt:P31 wd:Q5. OPTIONAL{?item wdt:P569 ?DR .}" +
+                "WHERE {VALUES ?item { " + itemValues + " } ?item wdt:P31 wd:Q5. ?item rdfs:label ?searchLabel. " +
+                "FILTER(LANG(?searchLabel) = 'en'). FILTER(REGEX(?searchLabel, \"" + escapedSearchPattern + "\", 'i')). " +
+                "OPTIONAL{?item wdt:P569 ?DR .}" +
                 " ?article schema:about ?item . ?article schema:inLanguage 'en'. ?article schema:isPartOf <https://en.wikipedia.org/>. " +
                 "OPTIONAL{?item wdt:P570 ?RIP .} " +
                 "OPTIONAL{?item wdt:P18 ?image .} " +
@@ -198,6 +201,16 @@ namespace WikiDataLib
             return Regex.Escape(searchString)
                 .Replace(@"\*", ".*")
                 .Replace(@"\?", ".");
+        }
+
+        private static string EscapeSparqlStringLiteral(string value)
+        {
+            return value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\r", "\\r")
+                .Replace("\n", "\\n")
+                .Replace("\t", "\\t");
         }
 
         private static string BuildPersonByIdQuery(int id)

--- a/WikiDataLib/WikiData.cs
+++ b/WikiDataLib/WikiData.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace WikiDataLib
 {
@@ -58,11 +60,17 @@ namespace WikiDataLib
                 throw new ArgumentException("Search string cannot be null or empty.", nameof(searchString));
             }
 
-            var encodedSearchString = Uri.EscapeDataString(searchString);
-            var query = BuildSearchQuery(encodedSearchString);
+            var searchPattern = BuildSearchPattern(searchString);
 
             try
             {
+                var entityIds = await SearchEntityIdsAsync(searchString, cancellationToken).ConfigureAwait(false);
+                if (entityIds.Count == 0)
+                {
+                    return new Collection<WikiPerson>();
+                }
+
+                var query = BuildSearchQuery(entityIds);
                 var root = await ExecuteSparqlQueryAsync(query, cancellationToken).ConfigureAwait(false);
 
                 if (!TryGetBindings(root, out var bindings))
@@ -70,15 +78,18 @@ namespace WikiDataLib
                     return new Collection<WikiPerson>();
                 }
 
-                var foundPersons = new Collection<WikiPerson>();
+                var idOrder = entityIds
+                    .Select((id, index) => new { id, index })
+                    .ToDictionary(item => item.id, item => item.index);
 
-                foreach (var item in bindings.EnumerateArray())
-                {
-                    var person = GetPersonFromJsonElement(item);
-                    foundPersons.Add(person);
-                }
+                var foundPersons = bindings
+                    .EnumerateArray()
+                    .Select(GetPersonFromJsonElement)
+                    .Where(person => person.Name != null && Regex.IsMatch(person.Name, searchPattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant))
+                    .OrderBy(person => idOrder.TryGetValue(person.Id, out var index) ? index : int.MaxValue)
+                    .ToList();
 
-                return foundPersons;
+                return new Collection<WikiPerson>(foundPersons);
             }
             catch (HttpRequestException ex)
             {
@@ -88,6 +99,41 @@ namespace WikiDataLib
             {
                 throw new JsonException("Failed to parse WikiData response.", ex);
             }
+        }
+
+        private static async Task<Collection<int>> SearchEntityIdsAsync(string searchString, CancellationToken cancellationToken)
+        {
+            var url = $"https://www.wikidata.org/w/api.php?action=query&list=search&srsearch={Uri.EscapeDataString(searchString)}&format=json&srlimit=50";
+            var root = await ExecuteJsonRequestAsync(url, cancellationToken).ConfigureAwait(false);
+
+            var entityIds = new Collection<int>();
+
+            if (!root.TryGetProperty("query", out var queryElement) ||
+                !queryElement.TryGetProperty("search", out var searchResults))
+            {
+                return entityIds;
+            }
+
+            foreach (var item in searchResults.EnumerateArray())
+            {
+                if (!item.TryGetProperty("title", out var titleProperty))
+                {
+                    continue;
+                }
+
+                var title = titleProperty.GetString();
+                if (title == null || title.Length <= 1 || title[0] != 'Q')
+                {
+                    continue;
+                }
+
+                if (int.TryParse(title.Substring(1), out var entityId))
+                {
+                    entityIds.Add(entityId);
+                }
+            }
+
+            return entityIds;
         }
 
         /// <summary>
@@ -133,16 +179,25 @@ namespace WikiDataLib
             }
         }
 
-        private static string BuildSearchQuery(string encodedSearchString)
+        private static string BuildSearchQuery(Collection<int> entityIds)
         {
+            var itemValues = string.Join(" ", entityIds.Select(id => $"wd:Q{id}"));
+
             return "SELECT distinct (SAMPLE(?image)as ?image) ?item ?itemLabel ?itemDescription" +
                 " (SAMPLE(?DR) as ?DR)(SAMPLE(?RIP) as ?RIP)(SAMPLE(?article) as ?article) " +
-                "WHERE {?item wdt:P31 wd:Q5. ?item ?label '" + encodedSearchString + "'@en. OPTIONAL{?item wdt:P569 ?DR .}" +
+                "WHERE {VALUES ?item { " + itemValues + " } ?item wdt:P31 wd:Q5. OPTIONAL{?item wdt:P569 ?DR .}" +
                 " ?article schema:about ?item . ?article schema:inLanguage 'en'. ?article schema:isPartOf <https://en.wikipedia.org/>. " +
                 "OPTIONAL{?item wdt:P570 ?RIP .} " +
                 "OPTIONAL{?item wdt:P18 ?image .} " +
                 "SERVICE wikibase:label { bd:serviceParam wikibase:language 'en'. }} " +
-                "GROUP BY ?item ?itemLabel ?itemDescription";
+                "GROUP BY ?item ?itemLabel ?itemDescription LIMIT 50";
+        }
+
+        private static string BuildSearchPattern(string searchString)
+        {
+            return Regex.Escape(searchString)
+                .Replace(@"\*", ".*")
+                .Replace(@"\?", ".");
         }
 
         private static string BuildPersonByIdQuery(int id)
@@ -161,6 +216,12 @@ namespace WikiDataLib
         private static async Task<JsonElement> ExecuteSparqlQueryAsync(string query, CancellationToken cancellationToken)
         {
             var url = $"{WikiDataSparqlEndpoint}?query={Uri.EscapeDataString(query)}&format=json";
+
+            return await ExecuteJsonRequestAsync(url, cancellationToken).ConfigureAwait(false);
+        }
+
+        private static async Task<JsonElement> ExecuteJsonRequestAsync(string url, CancellationToken cancellationToken)
+        {
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/WikiDataLib/WikiDataLib.csproj
+++ b/WikiDataLib/WikiDataLib.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -181,6 +181,16 @@ namespace WikiTest
         }
 
         [TestMethod]
+        public async Task WhenSearchingForPope_AllResultsShouldContainPopeInItemLabel()
+        {
+            var people = await WikiData.WikiPeopleSearchAsync("Pope");
+
+            Assert.IsTrue(people.Count > 0, "Search for 'Pope' should return results");
+            Assert.IsTrue(people.All(person => person.Name != null && person.Name.Contains("Pope", StringComparison.OrdinalIgnoreCase)),
+                "Search for 'Pope' should only return item labels containing 'Pope'");
+        }
+
+        [TestMethod]
         public async Task WhenGettingPersonById_ShouldHaveValidId()
         {
             var person = await WikiData.GetWikiPersonAsync(303);

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WikiDataLib;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -159,6 +160,24 @@ namespace WikiTest
             // Verify first result has a name
             var firstPerson = people[0];
             Assert.IsNotNull(firstPerson.Name, "First result should have a name");
+        }
+
+        [TestMethod]
+        public async Task WhenSearchingByPartialSurname_ShouldIncludeElvisPresley()
+        {
+            var people = await WikiData.WikiPeopleSearchAsync("Presley");
+
+            Assert.IsTrue(people.Any(person => person.Name == "Elvis Presley"),
+                "Search for 'Presley' should include Elvis Presley");
+        }
+
+        [TestMethod]
+        public async Task WhenSearchingWithWildcard_ShouldIncludeElvisPresley()
+        {
+            var people = await WikiData.WikiPeopleSearchAsync("*Presley*");
+
+            Assert.IsTrue(people.Any(person => person.Name == "Elvis Presley"),
+                "Search for '*Presley*' should include Elvis Presley");
         }
 
         [TestMethod]

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace WikiTest
+namespace WikiDataTest
 {
     [TestClass]
     public class WikiTests


### PR DESCRIPTION
## Summary
- switch people search to use Wikidata site search results as candidates instead of exact label matching
- support case-insensitive partial and wildcard (`*`, `?`) name matching before returning people
- add regression coverage and README notes for partial and wildcard search behavior

## Testing
- dotnet test --no-restore --nologo -v minimal --blame-crash --diag $env:TEMP\WikiDataLib-full-diag.txt

Fixes #38