### PR TITLE
Fix browser search CORS

### DIFF
--- a/WikiDataLib/README.md
+++ b/WikiDataLib/README.md
@@ -286,8 +286,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Changelog
 
-### v1.1.7 (Current)
-- Added partial and wildcard people search examples and documentation
+### v1.1.8 (Current)
+- Fixed browser-based `WikiPeopleSearchAsync` calls by enabling CORS on the MediaWiki search request
 
 ### v1.1.5
 - Fixed `System.Text.Json` version compatibility (`netstandard2.0` uses v8.0.5; `net10.0` uses built-in)

--- a/WikiDataLib/README.md
+++ b/WikiDataLib/README.md
@@ -289,6 +289,9 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ### v1.1.8 (Current)
 - Fixed browser-based `WikiPeopleSearchAsync` calls by enabling CORS on the MediaWiki search request
 
+### v1.1.7
+- Added partial and wildcard people search examples and documentation
+
 ### v1.1.5
 - Fixed `System.Text.Json` version compatibility (`netstandard2.0` uses v8.0.5; `net10.0` uses built-in)
 - Added exponential backoff retry logic (3 attempts) for transient WikiData SPARQL endpoint failures

--- a/WikiDataLib/WikiData.cs
+++ b/WikiDataLib/WikiData.cs
@@ -103,7 +103,7 @@ namespace WikiDataLib
 
         private static async Task<Collection<int>> SearchEntityIdsAsync(string searchString, CancellationToken cancellationToken)
         {
-            var url = $"https://www.wikidata.org/w/api.php?action=query&list=search&srsearch={Uri.EscapeDataString(searchString)}&format=json&srlimit=50";
+            var url = $"https://www.wikidata.org/w/api.php?action=query&list=search&srsearch={Uri.EscapeDataString(searchString)}&format=json&srlimit=50&origin=*";
             var root = await ExecuteJsonRequestAsync(url, cancellationToken).ConfigureAwait(false);
 
             var entityIds = new Collection<int>();

--- a/WikiDataLib/WikiDataLib.csproj
+++ b/WikiDataLib/WikiDataLib.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add the MediaWiki CORS opt-in parameter to browser search requests
- bump WikiDataLib package version to 1.1.8
- update the NuGet README changelog for the browser compatibility fix

## Testing
- dotnet test --no-restore --nologo -v minimal