### PR TITLE
Add WikiApi static class with Wikipedia REST API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
     int day,
     CancellationToken cancellationToken = default)
 
+public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+    int year,
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
 public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
     int month,
     int day,

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 A .NET library for accessing WikiData from your application. Targets `netstandard2.0` and `net10.0`.
 
 This release (v1.1.9) ensures label lookups fall back to the special "mul" (multiple languages) label when localized labels are missing, and prefers English, French, and Russian before falling back to `mul`. This improves reliability for high-profile entities that use language-agnostic labels (e.g., Q22686).
+The package also includes `WikiApi` for Wikipedia REST API lookups.
 
 Namespace: `WikiDataLib`
 
@@ -57,6 +58,42 @@ var person = await WikiData.GetWikiPersonAsync(303); // Q303 = Elvis Presley
 **Parameters:**
 - `id` — numeric WikiData entity ID, e.g. `303` for `Q303` (throws `ArgumentOutOfRangeException` if ≤ 0)
 - `cancellationToken` — optional cancellation token
+
+### `WikiData.GetWikiPersonAsync(string)`
+
+Get a person summary from Wikipedia by page title.
+
+```csharp
+public static Task<WikiPerson> GetWikiPersonAsync(
+    string wikipediaTitle,
+    CancellationToken cancellationToken = default)
+```
+
+### `WikiApi`
+
+Wikipedia REST API lookups.
+
+```csharp
+public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+    int year,
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<WikiPerson> GetWikiPersonAsync(
+    string wikipediaTitle,
+    CancellationToken cancellationToken = default)
+```
 
 ### `WikiData.GetPeopleBornOnDateAsync`
 

--- a/WikiDataLib/README.md
+++ b/WikiDataLib/README.md
@@ -151,6 +151,12 @@ public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
     int day,
     CancellationToken cancellationToken = default)
 
+public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+    int year,
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
 public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
     int month,
     int day,

--- a/WikiDataLib/README.md
+++ b/WikiDataLib/README.md
@@ -41,6 +41,10 @@ foreach (var person in people)
 // Get a specific person by WikiData ID (numeric part of Q-identifier)
 var elvis = await WikiData.GetWikiPersonAsync(303); // Q303 = Elvis Presley
 Console.WriteLine($"{elvis.Name} was born on {elvis.Birthday:yyyy-MM-dd}");
+
+// Get a summary directly from Wikipedia by page title
+var summary = await WikiData.GetWikiPersonAsync("Elvis Presley");
+Console.WriteLine(summary.Link);
 ```
 
 ## Advanced Usage
@@ -126,6 +130,42 @@ public static Task<WikiPerson> GetWikiPersonAsync(
 - `HttpRequestException` - When the WikiData API request fails
 - `JsonException` - When the response cannot be parsed
 - `TaskCanceledException` - When the operation is cancelled
+
+### `WikiData.GetWikiPersonAsync(string)`
+
+Gets a person summary from Wikipedia by page title.
+
+```csharp
+public static Task<WikiPerson> GetWikiPersonAsync(
+    string wikipediaTitle,
+    CancellationToken cancellationToken = default)
+```
+
+### `WikiApi`
+
+Wikipedia REST API lookups.
+
+```csharp
+public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+    int year,
+    int month,
+    int day,
+    CancellationToken cancellationToken = default)
+
+public static Task<WikiPerson> GetWikiPersonAsync(
+    string wikipediaTitle,
+    CancellationToken cancellationToken = default)
+```
 
 ### WikiData.GetPeopleBornOnDateAsync
 

--- a/WikiDataLib/WikiApi.cs
+++ b/WikiDataLib/WikiApi.cs
@@ -1,0 +1,398 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+
+namespace WikiDataLib
+{
+    /// <summary>
+    /// Provides access to Wikipedia REST API endpoints.
+    /// </summary>
+    public static class WikiApi
+    {
+        private const string WikiApiBaseUrl = "https://en.wikipedia.org/api/rest_v1";
+        private const string UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36";
+        private const int MaxRetryAttempts = 3;
+
+        private static readonly HttpClient _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+
+        private static readonly ConcurrentDictionary<string, JsonElement> _cache =
+            new ConcurrentDictionary<string, JsonElement>();
+
+        static WikiApi()
+        {
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
+        }
+
+        /// <summary>
+        /// Gets people born on a specific month and day from Wikipedia's "On this day" feed.
+        /// </summary>
+        public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+            int month,
+            int day,
+            CancellationToken cancellationToken = default)
+        {
+            return GetPeopleOnThisDayAsync("births", month, day, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets people born on a specific year, month, and day from Wikipedia's "On this day" feed.
+        /// </summary>
+        public static Task<Collection<WikiPerson>> GetBornOnDateAsync(
+            int year,
+            int month,
+            int day,
+            CancellationToken cancellationToken = default)
+        {
+            return GetPeopleOnThisDayAsync("births", month, day, year, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets people who died on a specific month and day from Wikipedia's "On this day" feed.
+        /// </summary>
+        public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+            int month,
+            int day,
+            CancellationToken cancellationToken = default)
+        {
+            return GetPeopleOnThisDayAsync("deaths", month, day, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets people who died on a specific year, month, and day from Wikipedia's "On this day" feed.
+        /// </summary>
+        public static Task<Collection<WikiPerson>> GetDiedOnDateAsync(
+            int year,
+            int month,
+            int day,
+            CancellationToken cancellationToken = default)
+        {
+            return GetPeopleOnThisDayAsync("deaths", month, day, year, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets a person summary from Wikipedia by title.
+        /// </summary>
+        public static async Task<WikiPerson> GetWikiPersonAsync(
+            string wikipediaTitle,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(wikipediaTitle))
+            {
+                throw new ArgumentException("Wikipedia title cannot be null or empty.", nameof(wikipediaTitle));
+            }
+
+            var url = $"{WikiApiBaseUrl}/page/summary/{Uri.EscapeDataString(wikipediaTitle)}";
+
+            try
+            {
+                var root = await ExecuteJsonRequestAsync(
+                    url,
+                    cancellationToken,
+                    notFoundMessage: $"No Wikipedia page found for title '{wikipediaTitle}'.").ConfigureAwait(false);
+
+                return BuildPersonFromSummary(root);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new HttpRequestException($"Failed to retrieve Wikipedia summary for '{wikipediaTitle}'.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new JsonException($"Failed to parse Wikipedia response for title '{wikipediaTitle}'.", ex);
+            }
+        }
+
+        private static async Task<Collection<WikiPerson>> GetPeopleOnThisDayAsync(
+            string eventType,
+            int month,
+            int day,
+            int? yearFilter,
+            CancellationToken cancellationToken)
+        {
+            ValidateMonthDay(month, day);
+
+            if (yearFilter.HasValue && yearFilter.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(yearFilter), "Year must be greater than 0.");
+            }
+
+            var url = $"{WikiApiBaseUrl}/feed/onthisday/{eventType}/{month}/{day}";
+
+            try
+            {
+                var root = await ExecuteJsonRequestAsync(url, cancellationToken).ConfigureAwait(false);
+
+                if (!root.TryGetProperty(eventType, out var events) || events.ValueKind != JsonValueKind.Array)
+                {
+                    return new Collection<WikiPerson>();
+                }
+
+                var people = new Collection<WikiPerson>();
+
+                foreach (var item in events.EnumerateArray())
+                {
+                    var year = ExtractIntProperty(item, "year");
+                    if (yearFilter.HasValue && year != yearFilter.Value)
+                    {
+                        continue;
+                    }
+
+                    if (!item.TryGetProperty("pages", out var pages) || pages.ValueKind != JsonValueKind.Array)
+                    {
+                        continue;
+                    }
+
+                    foreach (var page in pages.EnumerateArray())
+                    {
+                        people.Add(BuildPersonFromPage(page, month, day, year, eventType));
+                    }
+                }
+
+                return people;
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new HttpRequestException($"Failed to retrieve Wikipedia people {eventType} on {month}/{day}.", ex);
+            }
+            catch (JsonException ex)
+            {
+                throw new JsonException($"Failed to parse Wikipedia response for people {eventType} on {month}/{day}.", ex);
+            }
+        }
+
+        private static WikiPerson BuildPersonFromSummary(JsonElement root)
+        {
+            return new WikiPerson
+            {
+                Id = ExtractWikiEntityId(root),
+                Name = ExtractNormalizedTitle(root),
+                Description = ExtractStringProperty(root, "description"),
+                Image = ExtractThumbnailSource(root),
+                Link = ExtractPageUrl(root)
+            };
+        }
+
+        private static WikiPerson BuildPersonFromPage(JsonElement page, int month, int day, int year, string eventType)
+        {
+            var person = new WikiPerson
+            {
+                Id = ExtractWikiEntityId(page),
+                Name = ExtractNormalizedTitle(page),
+                Description = ExtractStringProperty(page, "description"),
+                Image = ExtractThumbnailSource(page),
+                Link = ExtractPageUrl(page)
+            };
+
+            var eventDate = TryCreateDate(year, month, day);
+            if (eventType == "births")
+            {
+                person.Birthday = eventDate;
+            }
+            else if (eventType == "deaths")
+            {
+                person.Death = eventDate;
+            }
+
+            return person;
+        }
+
+        private static int ExtractWikiEntityId(JsonElement item)
+        {
+            if (item.TryGetProperty("wikibase_item", out var wikibaseItem))
+            {
+                var itemValue = wikibaseItem.GetString();
+                if (!string.IsNullOrWhiteSpace(itemValue) &&
+                    itemValue.Length > 1 &&
+                    itemValue[0] == 'Q' &&
+                    int.TryParse(itemValue.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var wikidataId))
+                {
+                    return wikidataId;
+                }
+            }
+
+            if (item.TryGetProperty("pageid", out var pageId) && pageId.TryGetInt32(out var wikipediaPageId))
+            {
+                return wikipediaPageId;
+            }
+
+            return 0;
+        }
+
+        private static string? ExtractNormalizedTitle(JsonElement item)
+        {
+            if (item.TryGetProperty("titles", out var titles) &&
+                titles.TryGetProperty("normalized", out var normalizedTitle))
+            {
+                return normalizedTitle.GetString();
+            }
+
+            if (item.TryGetProperty("title", out var title))
+            {
+                var titleValue = title.GetString();
+                return titleValue?.Replace('_', ' ');
+            }
+
+            return null;
+        }
+
+        private static string? ExtractStringProperty(JsonElement item, string propertyName)
+        {
+            if (!item.TryGetProperty(propertyName, out var property))
+            {
+                return null;
+            }
+
+            return property.GetString();
+        }
+
+        private static string? ExtractThumbnailSource(JsonElement item)
+        {
+            if (item.TryGetProperty("thumbnail", out var thumbnail) &&
+                thumbnail.TryGetProperty("source", out var source))
+            {
+                return source.GetString();
+            }
+
+            return null;
+        }
+
+        private static string? ExtractPageUrl(JsonElement item)
+        {
+            if (!item.TryGetProperty("content_urls", out var contentUrls))
+            {
+                return null;
+            }
+
+            if (contentUrls.TryGetProperty("desktop", out var desktop) &&
+                desktop.TryGetProperty("page", out var pageUrl))
+            {
+                return pageUrl.GetString();
+            }
+
+            if (contentUrls.TryGetProperty("mobile", out var mobile) &&
+                mobile.TryGetProperty("page", out var mobilePageUrl))
+            {
+                return mobilePageUrl.GetString();
+            }
+
+            return null;
+        }
+
+        private static int ExtractIntProperty(JsonElement item, string propertyName)
+        {
+            if (!item.TryGetProperty(propertyName, out var property))
+            {
+                return 0;
+            }
+
+            if (property.TryGetInt32(out var value))
+            {
+                return value;
+            }
+
+            return 0;
+        }
+
+        private static DateTime? TryCreateDate(int year, int month, int day)
+        {
+            if (year <= 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                return new DateTime(year, month, day);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                return null;
+            }
+        }
+
+        private static void ValidateMonthDay(int month, int day)
+        {
+            if (month < 1 || month > 12)
+            {
+                throw new ArgumentOutOfRangeException(nameof(month), "Month must be between 1 and 12.");
+            }
+
+            var maxDay = DateTime.DaysInMonth(2000, month);
+            if (day < 1 || day > maxDay)
+            {
+                throw new ArgumentOutOfRangeException(nameof(day), $"Day must be between 1 and {maxDay} for month {month}.");
+            }
+        }
+
+        private static async Task<JsonElement> ExecuteJsonRequestAsync(
+            string url,
+            CancellationToken cancellationToken,
+            string? notFoundMessage = null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_cache.TryGetValue(url, out var cached))
+            {
+                return cached;
+            }
+
+            for (var attempt = 1; attempt <= MaxRetryAttempts; attempt++)
+            {
+                try
+                {
+                    using (var response = await _httpClient.GetAsync(url, cancellationToken).ConfigureAwait(false))
+                    {
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            var code = (int)response.StatusCode;
+                            if (code == 404 && notFoundMessage != null)
+                            {
+                                throw new InvalidOperationException(notFoundMessage);
+                            }
+
+                            var isTransient = code == 429 || code >= 500;
+                            if (isTransient && attempt < MaxRetryAttempts)
+                            {
+                                var delay = code == 429
+                                    ? TimeSpan.FromSeconds(Math.Pow(2, attempt + 1))
+                                    : TimeSpan.FromSeconds(Math.Pow(2, attempt));
+
+                                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                                continue;
+                            }
+
+                            response.EnsureSuccessStatusCode();
+                        }
+
+                        var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                        using (var doc = JsonDocument.Parse(json))
+                        {
+                            var result = doc.RootElement.Clone();
+                            _cache.TryAdd(url, result);
+                            return result;
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (attempt < MaxRetryAttempts &&
+                    (ex is HttpRequestException || ex is OperationCanceledException || ex is TaskCanceledException))
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempt)), cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new InvalidOperationException("Retry loop exhausted unexpectedly.");
+        }
+    }
+}

--- a/WikiDataLib/WikiApi.cs
+++ b/WikiDataLib/WikiApi.cs
@@ -376,6 +376,12 @@ namespace WikiDataLib
                         using (var doc = JsonDocument.Parse(json))
                         {
                             var result = doc.RootElement.Clone();
+
+                            if (_cache.Count >= 256)
+                            {
+                                _cache.Clear();
+                            }
+
                             _cache.TryAdd(url, result);
                             return result;
                         }

--- a/WikiDataLib/WikiData.cs
+++ b/WikiDataLib/WikiData.cs
@@ -181,6 +181,14 @@ namespace WikiDataLib
         }
 
         /// <summary>
+        /// Gets a specific person from Wikipedia by their page title.
+        /// </summary>
+        public static Task<WikiPerson> GetWikiPersonAsync(string wikipediaTitle, CancellationToken cancellationToken = default)
+        {
+            return WikiApi.GetWikiPersonAsync(wikipediaTitle, cancellationToken);
+        }
+
+        /// <summary>
         /// Gets people born on a specific month and day.
         /// </summary>
         public static Task<Collection<WikiPerson>> GetPeopleBornOnDateAsync(
@@ -189,7 +197,8 @@ namespace WikiDataLib
             int limit,
             CancellationToken cancellationToken = default)
         {
-            return GetPeopleOnDateAsync("P569", "born", month, day, limit, cancellationToken);
+            ValidateMonthDayLimit(month, day, limit);
+            return TrimResultsAsync(WikiApi.GetBornOnDateAsync(month, day, cancellationToken), limit);
         }
 
         /// <summary>
@@ -201,7 +210,8 @@ namespace WikiDataLib
             int limit,
             CancellationToken cancellationToken = default)
         {
-            return GetPeopleOnDateAsync("P570", "died", month, day, limit, cancellationToken);
+            ValidateMonthDayLimit(month, day, limit);
+            return TrimResultsAsync(WikiApi.GetDiedOnDateAsync(month, day, cancellationToken), limit);
         }
 
         /// <summary>
@@ -214,7 +224,8 @@ namespace WikiDataLib
             int limit,
             CancellationToken cancellationToken = default)
         {
-            return GetPeopleOnDateAsync("P570", "died", year, month, day, limit, cancellationToken);
+            ValidateYearMonthDayLimit(year, month, day, limit);
+            return TrimResultsAsync(WikiApi.GetDiedOnDateAsync(year, month, day, cancellationToken), limit);
         }
 
         /// <summary>
@@ -227,7 +238,16 @@ namespace WikiDataLib
             int limit,
             CancellationToken cancellationToken = default)
         {
-            return GetPeopleOnDateAsync("P569", "born", year, month, day, limit, cancellationToken);
+            ValidateYearMonthDayLimit(year, month, day, limit);
+            return TrimResultsAsync(WikiApi.GetBornOnDateAsync(year, month, day, cancellationToken), limit);
+        }
+
+        private static async Task<Collection<WikiPerson>> TrimResultsAsync(
+            Task<Collection<WikiPerson>> peopleTask,
+            int limit)
+        {
+            var people = await peopleTask.ConfigureAwait(false);
+            return new Collection<WikiPerson>(people.Take(limit).ToList());
         }
 
         private static string BuildSearchQuery(Collection<int> entityIds, string searchPattern)

--- a/WikiDataLib/WikiDataLib.csproj
+++ b/WikiDataLib/WikiDataLib.csproj
@@ -17,7 +17,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -28,6 +28,15 @@ namespace WikiDataTest
             Assert.AreEqual("Elvis Presley", person.Name);
         }
 
+        [TestMethod]
+        public async Task WhenGettingElvisPresleyByWikipediaTitle_ShouldReturnCorrectName()
+        {
+            var person = await WikiData.GetWikiPersonAsync("Elvis Presley");
+
+            Assert.IsNotNull(person);
+            Assert.AreEqual("Elvis Presley", person.Name);
+        }
+
         #endregion
 
         #region Input Validation Tests - WikiPeopleSearchAsync
@@ -325,7 +334,7 @@ namespace WikiDataTest
         {
             try
             {
-                var people = await WikiData.GetPeopleBornOnDateAsync(1, 8, 1);
+                var people = await WikiApi.GetBornOnDateAsync(1, 8);
 
                 Assert.IsNotNull(people);
                 Assert.IsTrue(people.Count > 0, "Expected at least one person born on January 8.");
@@ -333,11 +342,10 @@ namespace WikiDataTest
                     person.Birthday.Value.Month == 1 &&
                     person.Birthday.Value.Day == 8),
                     "All returned people should have a January 8 birthday.");
-                Assert.IsTrue(people.Count <= 1, "Result count should respect the supplied limit.");
             }
             catch (TaskCanceledException)
             {
-                Assert.Inconclusive("The public Wikidata SPARQL endpoint timed out for this live smoke test.");
+                Assert.Inconclusive("The public Wikipedia REST API timed out for this live smoke test.");
             }
         }
 
@@ -346,7 +354,7 @@ namespace WikiDataTest
         {
             try
             {
-                var people = await WikiData.GetPeopleDiedOnDateAsync(8, 16, 1);
+                var people = await WikiApi.GetDiedOnDateAsync(8, 16);
 
                 Assert.IsNotNull(people);
                 Assert.IsTrue(people.Count > 0, "Expected at least one person who died on August 16.");
@@ -354,11 +362,10 @@ namespace WikiDataTest
                     person.Death.Value.Month == 8 &&
                     person.Death.Value.Day == 16),
                     "All returned people should have an August 16 death date.");
-                Assert.IsTrue(people.Count <= 1, "Result count should respect the supplied limit.");
             }
             catch (TaskCanceledException)
             {
-                Assert.Inconclusive("The public Wikidata SPARQL endpoint timed out for this live smoke test.");
+                Assert.Inconclusive("The public Wikipedia REST API timed out for this live smoke test.");
             }
         }
 

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -372,10 +372,12 @@ namespace WikiDataTest
         {
             try
             {
-                var people = await WikiApi.GetDiedOnDateAsync(8, 16);
+                const int limit = 50;
+                var people = await WikiData.GetPeopleDiedOnDateAsync(8, 16, limit);
 
                 Assert.IsNotNull(people);
                 Assert.IsTrue(people.Count > 0, "Expected at least one person who died on August 16.");
+                Assert.IsTrue(people.Count <= limit, $"Expected at most {limit} results.");
                 Assert.IsTrue(people.All(person => person.Death.HasValue &&
                     person.Death.Value.Month == 8 &&
                     person.Death.Value.Day == 16),

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -350,10 +350,12 @@ namespace WikiDataTest
         {
             try
             {
-                var people = await WikiApi.GetBornOnDateAsync(1, 8);
+                const int limit = 50;
+                var people = await WikiData.GetPeopleBornOnDateAsync(1, 8, limit);
 
                 Assert.IsNotNull(people);
                 Assert.IsTrue(people.Count > 0, "Expected at least one person born on January 8.");
+                Assert.IsTrue(people.Count <= limit, $"Expected at most {limit} results.");
                 Assert.IsTrue(people.All(person => person.Birthday.HasValue &&
                     person.Birthday.Value.Month == 1 &&
                     person.Birthday.Value.Day == 8),

--- a/WikiDataTest/WikiTests.cs
+++ b/WikiDataTest/WikiTests.cs
@@ -37,6 +37,22 @@ namespace WikiDataTest
             Assert.AreEqual("Elvis Presley", person.Name);
         }
 
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow("   ")]
+        public async Task WhenGettingPersonByWikipediaTitle_IsEmptyOrWhitespace_ShouldThrowArgumentException(string wikipediaTitle)
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                async () => await WikiData.GetWikiPersonAsync(wikipediaTitle));
+        }
+
+        [TestMethod]
+        public async Task WhenGettingPersonByWikipediaTitle_IsNull_ShouldThrowArgumentException()
+        {
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                async () => await WikiData.GetWikiPersonAsync(null!));
+        }
+
         #endregion
 
         #region Input Validation Tests - WikiPeopleSearchAsync


### PR DESCRIPTION
Adds a new REST-backed WikiApi class for Wikipedia on-this-day lookups and page summaries, plus a WikiData.GetWikiPersonAsync(string) overload. Existing WikiData date methods now delegate to the REST API while preserving the legacy limit behavior for compatibility. Also updates docs and tests for the new API surface.